### PR TITLE
Correct a VERY silly typo.

### DIFF
--- a/pymechtest/base.py
+++ b/pymechtest/base.py
@@ -101,8 +101,8 @@ class BaseMechanicalTest:
             ) == (
                 other.folder,
                 other.id_row,
-                other.stress_col,
-                other.strain_col,
+                other._stress_col,
+                other._strain_col,
                 other.header,
                 other.strain1,
                 other.strain2,


### PR DESCRIPTION
I'd left a very silly typo in the __eq__ method
where the other class missed the underscore before
stress and strain_cols.

Now fixed.
