### PR TITLE
Remove redundant __eq__ method.

### DIFF
--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
-        <text x="80" y="14">99%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">98%</text>
+        <text x="80" y="14">98%</text>
     </g>
 </svg>

--- a/pymechtest/base.py
+++ b/pymechtest/base.py
@@ -85,31 +85,6 @@ class BaseMechanicalTest:
             f"expect_yield={self.expect_yield!r})"
         )
 
-    def __eq__(self, other: object) -> bool:
-
-        if not isinstance(other, BaseMechanicalTest):
-            return NotImplemented
-
-        return (
-            self.folder,
-            self.id_row,
-            self._stress_col,
-            self._strain_col,
-            self.header,
-            self.strain1,
-            self.strain2,
-            self.expect_yield,
-        ) == (
-            other.folder,
-            other.id_row,
-            other._stress_col,
-            other._strain_col,
-            other.header,
-            other.strain1,
-            other.strain2,
-            other.expect_yield,
-        )
-
     @property
     def stress_col(self) -> Union[str, None]:
         return self._stress_col

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,6 @@ Created: 28/11/2020
 
 import collections
 import json
-from pathlib import Path
 
 import altair as alt
 import pandas as pd
@@ -76,49 +75,6 @@ def test_base_repr():
         "header=8, "
         "strain1=0.05, strain2=0.15, expect_yield=False)"
     )
-
-
-def test_base_eq():
-
-    obj = BaseMechanicalTest(
-        folder="made/up/directory",
-        stress_col="BaseMechanicalTest stress",
-        strain_col="BaseMechanicalTest strain (Strain 1)",
-        id_row=3,
-        header=8,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    same = BaseMechanicalTest(
-        folder="made/up/directory",
-        stress_col="BaseMechanicalTest stress",
-        strain_col="BaseMechanicalTest strain (Strain 1)",
-        id_row=3,
-        header=8,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    diff = BaseMechanicalTest(
-        folder="different/made/up/directory",
-        stress_col="Different stress col",
-        strain_col="This doesn't match either",
-        id_row=6,
-        header=8,
-        strain1=0.025,
-        strain2=0.3,
-        expect_yield=True,
-    )
-
-    # Random different class, in this case a pathlib.Path
-    different_class = Path(__file__)
-
-    assert obj.__eq__(same) is True
-    assert obj.__eq__(diff) is False
-    assert obj.__eq__(different_class) is NotImplemented
 
 
 def test_basic_default_get_stress_strain_cols(

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -5,7 +5,6 @@ Author: Tom Fleet
 Created: 01/01/2021
 """
 
-from pathlib import Path
 
 from pymechtest import Compression
 
@@ -54,46 +53,3 @@ def test_compression_repr():
         "header=8, "
         "strain1=0.05, strain2=0.15, expect_yield=False)"
     )
-
-
-def test_compression_eq():
-
-    obj = Compression(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Compression stress",
-        strain_col="Compression strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    same = Compression(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Compression stress",
-        strain_col="Compression strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    diff = Compression(
-        folder="different/made/up/directory",
-        header=8,
-        stress_col="Different stress col",
-        strain_col="This doesn't match either",
-        id_row=6,
-        strain1=0.025,
-        strain2=0.3,
-        expect_yield=True,
-    )
-
-    # Random different class, in this case a pathlib.Path
-    different_class = Path(__file__)
-
-    assert obj.__eq__(same) is True
-    assert obj.__eq__(diff) is False
-    assert obj.__eq__(different_class) is NotImplemented

--- a/tests/test_flexure.py
+++ b/tests/test_flexure.py
@@ -5,7 +5,6 @@ Author: Tom Fleet
 Created: 01/01/2021
 """
 
-from pathlib import Path
 
 from pymechtest import Flexure
 
@@ -54,46 +53,3 @@ def test_flexure_repr():
         "header=8, "
         "strain1=0.05, strain2=0.15, expect_yield=False)"
     )
-
-
-def test_flexure_eq():
-
-    obj = Flexure(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Flexure stress",
-        strain_col="Flexure strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    same = Flexure(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Flexure stress",
-        strain_col="Flexure strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    diff = Flexure(
-        folder="different/made/up/directory",
-        header=8,
-        stress_col="Different stress col",
-        strain_col="This doesn't match either",
-        id_row=6,
-        strain1=0.025,
-        strain2=0.3,
-        expect_yield=True,
-    )
-
-    # Random different class, in this case a pathlib.Path
-    different_class = Path(__file__)
-
-    assert obj.__eq__(same) is True
-    assert obj.__eq__(diff) is False
-    assert obj.__eq__(different_class) is NotImplemented

--- a/tests/test_shear.py
+++ b/tests/test_shear.py
@@ -5,7 +5,6 @@ Author: Tom Fleet
 Created: 01/01/2021
 """
 
-from pathlib import Path
 
 from pymechtest import Shear
 
@@ -54,46 +53,3 @@ def test_shear_repr():
         "header=8, "
         "strain1=0.05, strain2=0.15, expect_yield=False)"
     )
-
-
-def test_shear_eq():
-
-    obj = Shear(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Shear stress",
-        strain_col="Shear strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    same = Shear(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Shear stress",
-        strain_col="Shear strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    diff = Shear(
-        folder="different/made/up/directory",
-        header=8,
-        stress_col="Different stress col",
-        strain_col="This doesn't match either",
-        id_row=6,
-        strain1=0.025,
-        strain2=0.3,
-        expect_yield=True,
-    )
-
-    # Random different class, in this case a pathlib.Path
-    different_class = Path(__file__)
-
-    assert obj.__eq__(same) is True
-    assert obj.__eq__(diff) is False
-    assert obj.__eq__(different_class) is NotImplemented

--- a/tests/test_tensile.py
+++ b/tests/test_tensile.py
@@ -5,7 +5,6 @@ Author: Tom Fleet
 Created: 01/01/2021
 """
 
-from pathlib import Path
 
 from pymechtest import Tensile
 
@@ -54,46 +53,3 @@ def test_tensile_repr():
         "header=8, "
         "strain1=0.05, strain2=0.15, expect_yield=False)"
     )
-
-
-def test_tensile_eq():
-
-    obj = Tensile(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Tensile stress",
-        strain_col="Tensile strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    same = Tensile(
-        folder="made/up/directory",
-        header=8,
-        stress_col="Tensile stress",
-        strain_col="Tensile strain (Strain 1)",
-        id_row=3,
-        strain1=0.05,
-        strain2=0.15,
-        expect_yield=False,
-    )
-
-    diff = Tensile(
-        folder="different/made/up/directory",
-        header=8,
-        stress_col="Different stress col",
-        strain_col="This doesn't match either",
-        id_row=6,
-        strain1=0.025,
-        strain2=0.3,
-        expect_yield=True,
-    )
-
-    # Random different class, in this case a pathlib.Path
-    different_class = Path(__file__)
-
-    assert obj.__eq__(same) is True
-    assert obj.__eq__(diff) is False
-    assert obj.__eq__(different_class) is NotImplemented


### PR DESCRIPTION
After some reading I've discovered you shouldn't really
implement a __eq__ unless you also have a __hash__ and at
this stage in the project both of these aren't really needed.

Removed all __eq__ methods and associated tests.
